### PR TITLE
(feature) AWS S3 module

### DIFF
--- a/matorage/config.py
+++ b/matorage/config.py
@@ -49,3 +49,4 @@ class StorageConfig(Serialize):
         self.access_key = kwargs.pop("access_key", None)
         self.secret_key = kwargs.pop("secret_key", None)
         self.secure = kwargs.pop("secure", False)
+        self.region = kwargs.pop("region", None)

--- a/matorage/data/config.py
+++ b/matorage/data/config.py
@@ -189,12 +189,44 @@ class DataConfig(StorageConfig):
         Returns:
             :obj: `None`:
         """
+
+        aws_region_list = [
+            'us-east-1',
+            'us-east-2',
+            'us-west-1',
+            'us-west-2',
+            'eu-west-1',
+            'eu-west-2',
+            'ca-central-1',
+            'eu-central-1',
+            'sa-east-1',
+            'cn-north-1',
+            'ap-southeast-1',
+            'ap-southeast-2',
+            'ap-northeast-1',
+            'ap-northeast-2',
+        ]
+
+        if "amazonaws.com" in self.endpoint:
+            if (self.region not in aws_region_list):
+                raise AssertionError(
+                    'AWS endpoint should has region argument from {}'.format(
+                        aws_region_list
+                    )
+                )
+            if f"s3.{self.region}.amazonaws.com" not in self.endpoint:
+                raise AssertionError('Endpoint has to be {}'.format(
+                        f"s3.{self.region}.amazonaws.com"
+                    )
+                )
+
         _client = (
             Minio(
                 self.endpoint,
                 access_key=self.access_key,
                 secret_key=self.secret_key,
                 secure=self.secure,
+                region=self.region,
             )
             if not check_nas(self.endpoint)
             else NAS(self.endpoint)

--- a/matorage/data/data.py
+++ b/matorage/data/data.py
@@ -111,6 +111,7 @@ class MTRData(object):
                 access_key=self.config.access_key,
                 secret_key=self.config.secret_key,
                 secure=self.config.secure,
+                region=self.config.region
             )
             if not check_nas(self.config.endpoint)
             else NAS(self.config.endpoint)

--- a/matorage/data/saver.py
+++ b/matorage/data/saver.py
@@ -142,6 +142,7 @@ class DataSaver(object):
                 access_key=self.config.access_key,
                 secret_key=self.config.secret_key,
                 secure=self.config.secure,
+                region=self.config.region,
             )
             if not check_nas(self.config.endpoint)
             else NAS(self.config.endpoint)
@@ -192,7 +193,9 @@ class DataSaver(object):
 
     def _check_and_create_bucket(self):
         if not self._client.bucket_exists(self.config.bucket_name):
-            self._client.make_bucket(self.config.bucket_name)
+            self._client.make_bucket(
+                self.config.bucket_name, location=self.config.region
+            )
 
     def _check_attr_name(self, name):
         """

--- a/matorage/model/config.py
+++ b/matorage/model/config.py
@@ -122,6 +122,7 @@ class ModelConfig(StorageConfig):
                 access_key=self.access_key,
                 secret_key=self.secret_key,
                 secure=self.secure,
+                region=self.config.region
             )
             if not check_nas(self.endpoint)
             else NAS(self.endpoint)

--- a/matorage/model/manager.py
+++ b/matorage/model/manager.py
@@ -44,6 +44,7 @@ class Manager(object):
                 access_key=self.config.access_key,
                 secret_key=self.config.secret_key,
                 secure=self.config.secure,
+                region=self.config.region,
             )
             if not check_nas(self.config.endpoint)
             else NAS(self.config.endpoint)
@@ -104,7 +105,9 @@ class Manager(object):
 
     def save(self, model, **kwargs):
         if not self._client.bucket_exists(self.config.bucket_name):
-            self._client.make_bucket(self.config.bucket_name)
+            self._client.make_bucket(
+                self.config.bucket_name, location=self.config.region
+            )
 
         if not isinstance(kwargs, dict):
             metadata = 0

--- a/matorage/nas.py
+++ b/matorage/nas.py
@@ -59,7 +59,7 @@ class NAS(object):
             ]
         return [Obj(o) for o in objects if o.startswith(prefix)]
 
-    def make_bucket(self, bucket_name):
+    def make_bucket(self, bucket_name, location):
         os.makedirs(os.path.join(self.path, bucket_name))
 
     def remove_bucket(self, bucket_name):

--- a/matorage/optimizer/config.py
+++ b/matorage/optimizer/config.py
@@ -122,6 +122,7 @@ class OptimizerConfig(StorageConfig):
                 access_key=self.access_key,
                 secret_key=self.secret_key,
                 secure=self.secure,
+                region=self.config.region
             )
             if not check_nas(self.endpoint)
             else NAS(self.endpoint)

--- a/matorage/optimizer/manager.py
+++ b/matorage/optimizer/manager.py
@@ -44,6 +44,7 @@ class Manager(object):
                 access_key=self.config.access_key,
                 secret_key=self.config.secret_key,
                 secure=self.config.secure,
+                region=self.config.region,
             )
             if not check_nas(self.config.endpoint)
             else NAS(self.config.endpoint)
@@ -107,7 +108,9 @@ class Manager(object):
 
     def save(self, optimizer):
         if not self._client.bucket_exists(self.config.bucket_name):
-            self._client.make_bucket(self.config.bucket_name)
+            self._client.make_bucket(
+                self.config.bucket_name, location=self.config.region
+            )
 
         step = self._get_step(optimizer)
         if not step:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -66,3 +66,29 @@ class DataTest(unittest.TestCase):
         if self.data_config_file is not None:
             if os.path.exists(self.data_config_file):
                 os.remove(self.data_config_file)
+
+
+@unittest.skipIf(
+    'access_key' not in os.environ or 'secret_key' not in os.environ, 'S3 Skip'
+)
+class DataS3Test(unittest.TestCase):
+
+    data_config = None
+    data_config_file = None
+    data_saver = None
+    dataset = None
+    storage_config = None
+
+    def tearDown(self):
+        if self.data_saver is not None:
+            # delete bucket
+            client = Minio(**self.storage_config)
+            objects = client.list_objects(self.data_config.bucket_name, recursive=True)
+            for obj in objects:
+                client.remove_object(self.data_config.bucket_name, obj.object_name)
+            client.remove_bucket(self.data_config.bucket_name)
+
+            # remove on local file
+            for _file in self.data_saver.get_filelist:
+                if os.path.exists(_file):
+                    os.remove(_file)

--- a/tests/test_datasaver.py
+++ b/tests/test_datasaver.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
+import os
 import unittest
 import numpy as np
 
-from tests.test_data import DataTest
+from tests.test_data import DataTest, DataS3Test
 
 from matorage.data.config import DataConfig
 from matorage.data.saver import DataSaver
@@ -28,21 +28,21 @@ class DataSaverTest(DataTest, unittest.TestCase):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_dataconfig_one_attribute",
-            attributes=DataAttribute("x", "uint8", (1))
+            attributes=DataAttribute("x", "uint8", (1)),
         )
 
     def test_dataconfig_one_attribute_with_tuple_attributes(self):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_dataconfig_one_attribute_with_tuple_attributes",
-            attributes=("x", "uint8", (1))
+            attributes=("x", "uint8", (1)),
         )
 
     def test_reload_dataconfig(self):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_reload_dataconfig",
-            attributes=DataAttribute("x", "uint8", (1))
+            attributes=DataAttribute("x", "uint8", (1)),
         )
         self.data_config_file = "data_config_file.json"
         self.data_config.to_json_file(self.data_config_file)
@@ -58,14 +58,14 @@ class DataSaverTest(DataTest, unittest.TestCase):
             attributes=[
                 DataAttribute("x", "uint8", (1)),
                 DataAttribute("y", "uint8", (1)),
-            ]
+            ],
         )
 
     def test_dataconfig_two_attribute_with_tuple_attributes(self):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_dataconfig_two_attribute_with_tuple_attributes",
-            attributes=[("x", "uint8", (1)), ("y", "uint8", (1))]
+            attributes=[("x", "uint8", (1)), ("y", "uint8", (1))],
         )
 
     def test_dataconfig_attributes_already_exist(self):
@@ -76,91 +76,91 @@ class DataSaverTest(DataTest, unittest.TestCase):
                 attributes=[
                     DataAttribute("x", "uint8", (1)),
                     DataAttribute("x", "uint8", (1)),
-                ]
+                ],
             )
 
     def test_dataconfig_string_attribute(self):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_dataconfig_string_attribute",
-            attributes=[DataAttribute("x", "string", (1), itemsize=32)]
+            attributes=[DataAttribute("x", "string", (1), itemsize=32)],
         )
 
     def test_dataconfig_bool_attribute(self):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_dataconfig_bool_attribute",
-            attributes=[DataAttribute("x", "bool", (1))]
+            attributes=[DataAttribute("x", "bool", (1))],
         )
 
     def test_dataconfig_int8_attribute(self):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_dataconfig_int8_attribute",
-            attributes=[DataAttribute("x", "int8", (1))]
+            attributes=[DataAttribute("x", "int8", (1))],
         )
 
     def test_dataconfig_int16_attribute(self):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_dataconfig_int16_attribute",
-            attributes=[DataAttribute("x", "int16", (1))]
+            attributes=[DataAttribute("x", "int16", (1))],
         )
 
     def test_dataconfig_int32_attribute(self):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_dataconfig_int32_attribute",
-            attributes=[DataAttribute("x", "int32", (1))]
+            attributes=[DataAttribute("x", "int32", (1))],
         )
 
     def test_dataconfig_uint8_attribute(self):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_dataconfig_uint8_attribute",
-            attributes=[DataAttribute("x", "uint8", (1))]
+            attributes=[DataAttribute("x", "uint8", (1))],
         )
 
     def test_dataconfig_uint16_attribute(self):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_dataconfig_uint16_attribute",
-            attributes=[DataAttribute("x", "uint16", (1))]
+            attributes=[DataAttribute("x", "uint16", (1))],
         )
 
     def test_dataconfig_uint32_attribute(self):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_dataconfig_uint32_attribute",
-            attributes=[DataAttribute("x", "uint32", (1))]
+            attributes=[DataAttribute("x", "uint32", (1))],
         )
 
     def test_dataconfig_uint64_attribute(self):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_dataconfig_uint64_attribute",
-            attributes=[DataAttribute("x", "uint64", (1))]
+            attributes=[DataAttribute("x", "uint64", (1))],
         )
 
     def test_dataconfig_float32_attribute(self):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_dataconfig_float32_attribute",
-            attributes=[DataAttribute("x", "float32", (1))]
+            attributes=[DataAttribute("x", "float32", (1))],
         )
 
     def test_dataconfig_float64_attribute(self):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_dataconfig_float64_attribute",
-            attributes=[DataAttribute("x", "float64", (1))]
+            attributes=[DataAttribute("x", "float64", (1))],
         )
 
     def test_datasaver_string_attribute(self):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_datasaver_string_attribute",
-            attributes=[DataAttribute("x", "string", (2), itemsize=32)]
+            attributes=[DataAttribute("x", "string", (2), itemsize=32)],
         )
         self.data_saver = DataSaver(config=self.data_config)
         x = np.asarray([["a", "b"], ["c", "d"], ["e", "f"]])
@@ -171,7 +171,7 @@ class DataSaverTest(DataTest, unittest.TestCase):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_datasaver_bool_attribute",
-            attributes=[DataAttribute("x", "bool", (2), itemsize=32)]
+            attributes=[DataAttribute("x", "bool", (2), itemsize=32)],
         )
         self.data_saver = DataSaver(config=self.data_config)
         x = np.asarray([[True, False], [False, True], [True, True]])
@@ -182,7 +182,7 @@ class DataSaverTest(DataTest, unittest.TestCase):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_datasaver_int8_attribute",
-            attributes=[DataAttribute("x", "int8", (2), itemsize=32)]
+            attributes=[DataAttribute("x", "int8", (2), itemsize=32)],
         )
         self.data_saver = DataSaver(config=self.data_config)
         x = np.asarray([[1, 2], [3, 4], [5, 6]])
@@ -193,7 +193,7 @@ class DataSaverTest(DataTest, unittest.TestCase):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_datasaver_int16_attribute",
-            attributes=[DataAttribute("x", "int16", (2), itemsize=32)]
+            attributes=[DataAttribute("x", "int16", (2), itemsize=32)],
         )
         self.data_saver = DataSaver(config=self.data_config)
         x = np.asarray([[1, 2], [3, 4], [5, 6]])
@@ -204,7 +204,7 @@ class DataSaverTest(DataTest, unittest.TestCase):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_datasaver_int32_attribute",
-            attributes=[DataAttribute("x", "int32", (2), itemsize=32)]
+            attributes=[DataAttribute("x", "int32", (2), itemsize=32)],
         )
         self.data_saver = DataSaver(config=self.data_config)
         x = np.asarray([[1, 2], [3, 4], [5, 6]])
@@ -215,7 +215,7 @@ class DataSaverTest(DataTest, unittest.TestCase):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_datasaver_int64_attribute",
-            attributes=[DataAttribute("x", "int64", (2), itemsize=32)]
+            attributes=[DataAttribute("x", "int64", (2), itemsize=32)],
         )
         self.data_saver = DataSaver(config=self.data_config)
         x = np.asarray([[1, 2], [3, 4], [5, 6]])
@@ -226,7 +226,7 @@ class DataSaverTest(DataTest, unittest.TestCase):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_datasaver_uint8_attribute",
-            attributes=[DataAttribute("x", "uint8", (2), itemsize=32)]
+            attributes=[DataAttribute("x", "uint8", (2), itemsize=32)],
         )
         self.data_saver = DataSaver(config=self.data_config)
         x = np.asarray([[1, 2], [3, 4], [5, 6]])
@@ -237,7 +237,7 @@ class DataSaverTest(DataTest, unittest.TestCase):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_datasaver_uint16_attribute",
-            attributes=[DataAttribute("x", "uint16", (2), itemsize=32)]
+            attributes=[DataAttribute("x", "uint16", (2), itemsize=32)],
         )
         self.data_saver = DataSaver(config=self.data_config)
         x = np.asarray([[1, 2], [3, 4], [5, 6]])
@@ -248,7 +248,7 @@ class DataSaverTest(DataTest, unittest.TestCase):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_datasaver_uint32_attribute",
-            attributes=[DataAttribute("x", "uint32", (2), itemsize=32)]
+            attributes=[DataAttribute("x", "uint32", (2), itemsize=32)],
         )
         self.data_saver = DataSaver(config=self.data_config)
         x = np.asarray([[1, 2], [3, 4], [5, 6]])
@@ -259,7 +259,7 @@ class DataSaverTest(DataTest, unittest.TestCase):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_datasaver_uint64_attribute",
-            attributes=[DataAttribute("x", "uint64", (2), itemsize=32)]
+            attributes=[DataAttribute("x", "uint64", (2), itemsize=32)],
         )
         self.data_saver = DataSaver(config=self.data_config)
         x = np.asarray([[1, 2], [3, 4], [5, 6]])
@@ -270,7 +270,7 @@ class DataSaverTest(DataTest, unittest.TestCase):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_datasaver_float32_attribute",
-            attributes=[DataAttribute("x", "float32", (2), itemsize=32)]
+            attributes=[DataAttribute("x", "float32", (2), itemsize=32)],
         )
         self.data_saver = DataSaver(config=self.data_config)
         x = np.asarray([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
@@ -281,7 +281,7 @@ class DataSaverTest(DataTest, unittest.TestCase):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_datasaver_float64_attribute",
-            attributes=[DataAttribute("x", "float64", (2), itemsize=32)]
+            attributes=[DataAttribute("x", "float64", (2), itemsize=32)],
         )
         self.data_saver = DataSaver(config=self.data_config)
         x = np.asarray([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
@@ -292,7 +292,7 @@ class DataSaverTest(DataTest, unittest.TestCase):
         self.data_config = DataConfig(
             **self.storage_config,
             dataset_name="test_datasaver_inmemory",
-            attributes=[DataAttribute("x", "float64", (2), itemsize=32)]
+            attributes=[DataAttribute("x", "float64", (2), itemsize=32)],
         )
         self.data_saver = DataSaver(config=self.data_config, inmemory=True)
         x = np.asarray([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
@@ -305,7 +305,7 @@ class DataSaverTest(DataTest, unittest.TestCase):
                 **self.storage_config,
                 dataset_name="test_datasaver_zlib",
                 attributes=[DataAttribute("x", "float64", (2), itemsize=32)],
-                compressor={"complevel": level, "complib": "zlib"}
+                compressor={"complevel": level, "complib": "zlib"},
             )
             self.data_saver = DataSaver(config=self.data_config)
             x = np.asarray([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
@@ -318,7 +318,7 @@ class DataSaverTest(DataTest, unittest.TestCase):
                 **self.storage_config,
                 dataset_name="test_datasaver_lzo",
                 attributes=[DataAttribute("x", "float64", (2), itemsize=32)],
-                compressor={"complevel": level, "complib": "lzo"}
+                compressor={"complevel": level, "complib": "lzo"},
             )
             self.data_saver = DataSaver(config=self.data_config)
             x = np.asarray([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
@@ -331,7 +331,7 @@ class DataSaverTest(DataTest, unittest.TestCase):
                 **self.storage_config,
                 dataset_name="test_datasaver_bzip2",
                 attributes=[DataAttribute("x", "float64", (2), itemsize=32)],
-                compressor={"complevel": level, "complib": "bzip2"}
+                compressor={"complevel": level, "complib": "bzip2"},
             )
             self.data_saver = DataSaver(config=self.data_config)
             x = np.asarray([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
@@ -344,7 +344,7 @@ class DataSaverTest(DataTest, unittest.TestCase):
                 **self.storage_config,
                 dataset_name="test_datasaver_blosc",
                 attributes=[DataAttribute("x", "float64", (2), itemsize=32)],
-                compressor={"complevel": level, "complib": "blosc"}
+                compressor={"complevel": level, "complib": "blosc"},
             )
             self.data_saver = DataSaver(config=self.data_config)
             x = np.asarray([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
@@ -364,8 +364,36 @@ class DataSaverTest(DataTest, unittest.TestCase):
         self.data_saver({"x": x})
 
 
+@unittest.skipIf(
+    'access_key' not in os.environ or 'secret_key' not in os.environ, 'S3 Skip'
+)
+class DataS3SaverTest(DataS3Test, unittest.TestCase):
+    def test_datasaver_s3(self):
+        self.storage_config = {
+            'endpoint': 's3.us-east-1.amazonaws.com',
+            'access_key': os.environ['access_key'],
+            'secret_key': os.environ['secret_key'],
+            'region': 'us-east-1',
+            'secure': False,
+        }
+
+        self.data_config = DataConfig(
+            **self.storage_config,
+            dataset_name="test_datasaver_s3",
+            attributes=[DataAttribute("x", "float64", (2), itemsize=32)],
+        )
+        self.data_saver = DataSaver(config=self.data_config)
+        x = np.asarray([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        self.assertEqual(x.shape, (3, 2))
+        self.data_saver({"x": x})
+        self.data_saver.disconnect()
+
+
 def suite():
-    return unittest.TestSuite(unittest.makeSuite(DataSaverTest))
+    suties = unittest.TestSuite()
+    suties.addTests(unittest.makeSuite(DataSaverTest))
+    suties.addTests(unittest.makeSuite(DataS3SaverTest))
+    return suties
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Finish workflow for AWS S3 module
- Add region argument for the input of minio client in DataConfig, ModelConfig, OptimizerConfig and Managers
- Add region argument(location) when the bucket is created
- Add unittest for DataS3Saver

For an example:

```python
import numpy as np
from matorage import *

if __name__ == '__main__':
    data_config = DataConfig(
        endpoint='s3.us-east-1.amazonaws.com',
        access_key='access_key',
        secret_key='secret_key',
        region='us-east-1',
        dataset_name="test_datasaver_s3",
        attributes=[DataAttribute("x", "float64", (2), itemsize=32)],
    )
    data_saver = DataSaver(config=data_config)
    x = np.asarray([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
    data_saver({"x": x})
    data_saver.disconnect()
```