### PR TITLE
(fixed) mistake self.config.region to self.region

### DIFF
--- a/matorage/model/config.py
+++ b/matorage/model/config.py
@@ -122,7 +122,7 @@ class ModelConfig(StorageConfig):
                 access_key=self.access_key,
                 secret_key=self.secret_key,
                 secure=self.secure,
-                region=self.config.region
+                region=self.region
             )
             if not check_nas(self.endpoint)
             else NAS(self.endpoint)

--- a/matorage/optimizer/config.py
+++ b/matorage/optimizer/config.py
@@ -122,7 +122,7 @@ class OptimizerConfig(StorageConfig):
                 access_key=self.access_key,
                 secret_key=self.secret_key,
                 secure=self.secure,
-                region=self.config.region
+                region=self.region
             )
             if not check_nas(self.endpoint)
             else NAS(self.endpoint)


### PR DESCRIPTION
- (hotfix) change from `self.config.region` to `self.region`