### PR TITLE
Hotfix about unittest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ services:
   - docker
 
 before_install:
+  - mkdir ~/shared
   - docker pull minio/minio
-  - docker run -d -p 9000:9000 --restart always -e "MINIO_ACCESS_KEY=minio" -e "MINIO_SECRET_KEY=miniosecretkey" minio/minio
+  - docker run -it -d -p 9000:9000 --restart always -e "MINIO_ACCESS_KEY=minio" -e "MINIO_SECRET_KEY=miniosecretkey" -v ~/shared:/container/vol minio/minio gateway nas /container/vol
 
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,4 @@ script:
       python -c "import tensorflow_io as tfio; print('Tensorflow IO Version:', tfio.__version__)";
     fi
   - python setup.py install;
-  - python -m unittest tests/test_suite.py;
+  - python -m tests.test_suite;

--- a/matorage/data/config.py
+++ b/matorage/data/config.py
@@ -254,7 +254,7 @@ class DataConfig(StorageConfig):
                 DataAttribute(**item) for item in metadata_dict["attributes"]
             ]
         else:
-            logger.warn(
+            logger.info(
                 "{} {} is not exist!".format(self.dataset_name, str(self.additional))
             )
 

--- a/matorage/model/config.py
+++ b/matorage/model/config.py
@@ -149,7 +149,7 @@ class ModelConfig(StorageConfig):
             self.compressor = metadata_dict["compressor"]
             self.metadata = metadata_dict
         else:
-            logger.warn(
+            logger.info(
                 "{} {} is not exist!".format(self.model_name, str(self.additional))
             )
 

--- a/matorage/model/manager.py
+++ b/matorage/model/manager.py
@@ -117,7 +117,7 @@ class Manager(object):
         model_folder = self._hashmap_transfer(metadata)
 
         if model_folder in self.config.metadata["model"]:
-            logger.warn(
+            logger.info(
                 "{} {} is already exist, so model will be overwrited.".format(
                     self.config.model_name, str(self.config.additional)
                 )

--- a/matorage/optimizer/config.py
+++ b/matorage/optimizer/config.py
@@ -149,7 +149,7 @@ class OptimizerConfig(StorageConfig):
             self.compressor = metadata_dict["compressor"]
             self.metadata = metadata_dict
         else:
-            logger.warn(
+            logger.info(
                 "{} {} is not exist!".format(self.optimizer_name, str(self.additional))
             )
 

--- a/matorage/optimizer/manager.py
+++ b/matorage/optimizer/manager.py
@@ -122,7 +122,7 @@ class Manager(object):
             return
 
         if step in self.config.metadata["optimizer"]:
-            logger.warn(
+            logger.info(
                 "{} {} is already exist, so optimizer will be overwrited.".format(
                     self.config.optimizer_name, str(self.config.additional)
                 )

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -43,3 +43,6 @@ def test(verbose=False):
         return 0
     else:
         return 1
+
+if __name__ == '__main__':
+    test()


### PR DESCRIPTION
- Before `python -m unittest` didn't work well.
- Change from logger warn to info 