### PR TITLE
(fixed) list_objects, not use caching in NAS

### DIFF
--- a/matorage/data/data.py
+++ b/matorage/data/data.py
@@ -74,7 +74,10 @@ class MTRData(object):
 
         if not self.index:
             # cache object which is downloaded.
-            self._caching(cache_folder_path=cache_folder_path)
+            if not check_nas(self.config.endpoint):
+                self._caching(cache_folder_path=cache_folder_path)
+            else:
+                self._object_file_mapper = {}
 
             # download all object in /tmp folder
             self._init_download()
@@ -188,7 +191,7 @@ class MTRData(object):
 
         assert len(self._object_file_mapper) == (len(self.merged_indexer) + len(self.merged_filetype))
 
-        if not os.path.exists(self.cache_path):
+        if not check_nas(self.config.endpoint) and not os.path.exists(self.cache_path):
             with open(self.cache_path, "w") as f:
                 json.dump(self._object_file_mapper, f)
             logger.info(

--- a/matorage/nas.py
+++ b/matorage/nas.py
@@ -50,9 +50,11 @@ class NAS(object):
             shutil.copyfileobj(data, f, length=length)
 
     def list_objects(self, bucket_name, prefix="", recursive=False):
-        _foldername = os.path.join(self.path, bucket_name)
+        _foldername = os.path.join(self.path, bucket_name, prefix)
         if not recursive:
-            objects = os.listdir(_foldername)
+            objects = [
+                os.path.join(prefix, f) for f in os.listdir(_foldername)
+            ]
         else:
             objects = [
                 os.path.join(dp, f) for dp, dn, fn in os.walk(_foldername) for f in fn


### PR DESCRIPTION
#21, #22
- Fixed the `list_object` function overridden in NAS.
   - previous(Cause of error): `_client.list_objects(self.bucket_name, prefix="metadata/")` -> ['a.h5']
   - current(Right) : `_client.list_objects(self.bucket_name, prefix="metadata/")` -> ['metadata/a.h5']
- Fixed not use caching when using NAS.