### PR TITLE
(fixed) prevent file not found error in NAS `put_object`

### DIFF
--- a/matorage/nas.py
+++ b/matorage/nas.py
@@ -33,8 +33,7 @@ class NAS(object):
 
     def fput_object(self, bucket_name, object_name, file_path, part_size=None):
         _filename = os.path.join(self.path, bucket_name, object_name)
-        if not os.path.exists(os.path.dirname(_filename)):
-            os.makedirs(os.path.dirname(_filename))
+        os.makedirs(os.path.dirname(_filename), exist_ok=True)
         shutil.copyfile(src=file_path, dst=_filename)
 
     def get_object(self, bucket_name, object_name):
@@ -43,8 +42,7 @@ class NAS(object):
 
     def put_object(self, bucket_name, object_name, data, length, part_size=None):
         _filename = os.path.join(self.path, bucket_name, object_name)
-        if not os.path.exists(os.path.dirname(_filename)):
-            os.makedirs(os.path.dirname(_filename))
+        os.makedirs(os.path.dirname(_filename), exist_ok=True)
         data.seek(0)
         with open(_filename, "wb") as f:
             shutil.copyfileobj(data, f, length=length)


### PR DESCRIPTION
To prevent below error: #21
```bash
nlkey2022@instance-1:~/matorage/examples/pytorch/mnist$ python3 run_mnist.py --train --test
08/31/2020 11:29:17 - INFO - matorage.utils - PID: 16390 -  PyTorch version 1.6.0 available.
08/31/2020 11:29:17 - INFO - matorage.utils - PID: 16390 -  PyTorch Vision version 0.7.0 available.
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/matorage-0.0.0-py3.6.egg/matorage/model/config.py", line 127, in _check_bucket
    _metadata = _client.get_object(self.bucket_name, "metadata.json")
  File "/usr/local/lib/python3.6/dist-packages/matorage-0.0.0-py3.6.egg/matorage/nas.py", line 41, in get_object
    return open(_filename, "rb")
FileNotFoundError: [Errno 2] No such file or directory: '/home/nlkey2022/shared/model57f0ab2d28999414a262418dda9191be/metadata.json'
```