### PR TITLE
Add and fix unittests for NAS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ services:
   - docker
 
 before_install:
-  - mkdir ~/shared
+  - mkdir ~/unittest
   - docker pull minio/minio
-  - docker run -it -d -p 9000:9000 --restart always -e "MINIO_ACCESS_KEY=minio" -e "MINIO_SECRET_KEY=miniosecretkey" -v ~/shared:/container/vol minio/minio gateway nas /container/vol
+  - docker run -it -d -p 9001:9000 --restart always -e "MINIO_ACCESS_KEY=minio" -e "MINIO_SECRET_KEY=miniosecretkey" -v ~/unittest:/container/vol minio/minio gateway nas /container/vol
 
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ services:
   - docker
 
 before_install:
-  - mkdir ~/unittest
+  - mkdir /tmp/unittest
   - docker pull minio/minio
-  - docker run -it -d -p 9001:9000 --restart always -e "MINIO_ACCESS_KEY=minio" -e "MINIO_SECRET_KEY=miniosecretkey" -v ~/unittest:/container/vol minio/minio gateway nas /container/vol
+  - docker run -it -d -p 9001:9000 --restart always -e "MINIO_ACCESS_KEY=minio" -e "MINIO_SECRET_KEY=miniosecretkey" -v /tmp/unittest:/container/vol minio/minio gateway nas /container/vol
 
 # command to install dependencies
 install:

--- a/matorage/nas.py
+++ b/matorage/nas.py
@@ -77,4 +77,8 @@ class NAS(object):
         shutil.rmtree(os.path.join(self.path, bucket_name))
 
     def remove_object(self, bucket_name, object_name):
-        os.remove(os.path.join(self.path, bucket_name, object_name))
+        _path = os.path.join(self.path, bucket_name, object_name)
+        if os.path.isdir(_path):
+            shutil.rmtree(_path)
+        else:
+            os.remove(_path)

--- a/matorage/nas.py
+++ b/matorage/nas.py
@@ -53,8 +53,10 @@ class NAS(object):
         _query = os.path.join(self.path, bucket_name, prefix)
         objects = []
 
-        if prefix:
-            assert '/' in prefix, "prefix should have slash."
+        if '/' in _query:
+            _query = _query.rsplit('/', 1)[0] + '/'
+        else:
+            _query = _base
 
         for f in iglob(f"{_query}/**", recursive=recursive):
             if os.path.isdir(f):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -26,7 +26,7 @@ class DataTest(unittest.TestCase):
     data_saver = None
     dataset = None
     storage_config = {
-        "endpoint": "127.0.0.1:9000",
+        "endpoint": "127.0.0.1:9001",
         "access_key": "minio",
         "secret_key": "miniosecretkey",
         "secure": False,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -32,7 +32,7 @@ class DataTest(unittest.TestCase):
         "secure": False,
     }
     nas_config = {
-        "endpoint": "/tmp",
+        "endpoint": "/tmp/unittest",
     }
 
     def check_nas(self, endpoint):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -31,6 +31,9 @@ class DataTest(unittest.TestCase):
         "secret_key": "miniosecretkey",
         "secure": False,
     }
+    nas_config = {
+        "endpoint": "/tmp",
+    }
 
     def check_nas(self, endpoint):
         _url_or_path = "//" + endpoint
@@ -59,7 +62,7 @@ class DataTest(unittest.TestCase):
                 if os.path.exists(_file):
                     os.remove(_file)
 
-        if self.dataset is not None:
+        if self.dataset is not None and not self.check_nas(self.dataset.config.endpoint):
             if os.path.exists(self.dataset.cache_path):
                 os.remove(self.dataset.cache_path)
 

--- a/tests/test_datasaver.py
+++ b/tests/test_datasaver.py
@@ -371,7 +371,7 @@ class DataSaverTest(DataTest, unittest.TestCase):
     def test_datasaver_nas(self):
 
         self.data_config = DataConfig(
-            endpoint="/tmp",
+            endpoint="/tmp/unittest",
             dataset_name="test_datasaver_nas",
             attributes=[DataAttribute("x", "float64", (2), itemsize=32)],
         )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -31,7 +31,7 @@ class ModelTest(unittest.TestCase):
         "secure": False,
     }
     nas_config = {
-        "endpoint": "/tmp",
+        "endpoint": "/tmp/unittest",
     }
 
     def check_nas(self, endpoint):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -25,7 +25,7 @@ class ModelTest(unittest.TestCase):
     model_config_file = None
     model_manager = None
     storage_config = {
-        "endpoint": "127.0.0.1:9000",
+        "endpoint": "127.0.0.1:9001",
         "access_key": "minio",
         "secret_key": "miniosecretkey",
         "secure": False,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -30,6 +30,9 @@ class ModelTest(unittest.TestCase):
         "secret_key": "miniosecretkey",
         "secure": False,
     }
+    nas_config = {
+        "endpoint": "/tmp",
+    }
 
     def check_nas(self, endpoint):
         _url_or_path = "//" + endpoint

--- a/tests/test_nas.py
+++ b/tests/test_nas.py
@@ -1,0 +1,110 @@
+# Copyright 2020-present Tae Hwan Jung
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+from minio import Minio
+
+from tests.test_storage import StorageTest
+
+from matorage.nas import NAS
+
+class DataSaverTest(StorageTest, unittest.TestCase):
+    minio_config = Minio(
+        endpoint="127.0.0.1:9000",
+        access_key="minio",
+        secret_key="miniosecretkey",
+        secure=False,
+    )
+    nas_config = NAS(path="/tmp")
+
+    def _create_bucket(self):
+        self.minio_config.make_bucket('testminio')
+        self.nas_config.make_bucket('testnas')
+
+    def _get_obj_names(self, generator):
+        res = sorted([g.object_name for g in generator])
+        return res
+
+    def _check_assertEqual(self, prefix=''):
+        for r in [True, False]:
+            self.assertEqual(
+                self._get_obj_names(
+                    self.minio_config.list_objects('testminio', prefix=prefix, recursive=r)
+                ),
+                self._get_obj_names(
+                    self.nas_config.list_objects('testnas', prefix=prefix, recursive=r)
+                )
+            )
+
+    def test_bucket_exists(self):
+        self._create_bucket()
+        self.assertEqual(
+            self.minio_config.bucket_exists('testminio'),
+            self.nas_config.bucket_exists('testnas')
+        )
+
+    def test_fput_object_with_list_objects(self):
+        self._create_bucket()
+
+        with open('test', 'w') as f:
+            f.write('this is test')
+
+        for _object_name in ['test', 'metadata/test']:
+            self.minio_config.fput_object(
+                bucket_name='testminio',
+                object_name=_object_name,
+                file_path='test'
+            )
+        for _object_name in ['test', 'metadata/test']:
+            self.nas_config.fput_object(
+                bucket_name='testnas',
+                object_name=_object_name,
+                file_path='test'
+            )
+
+        self._check_assertEqual(prefix='')
+        self._check_assertEqual(prefix='metadata/')
+        self._check_assertEqual(prefix='metadata')
+        self._check_assertEqual(prefix='meta')
+
+        self._check_assertEqual(prefix='metadata/t')
+        self._check_assertEqual(prefix='metadata/test')
+
+        self.assertEqual(
+            self._get_obj_names(
+                self.minio_config.list_objects('testminio', prefix='metadata/test/')
+            ),
+            self._get_obj_names(
+                self.nas_config.list_objects('testnas', prefix='metadata/test/')
+            )
+        )
+
+        self.assertNotEqual(
+            self._get_obj_names(
+                self.minio_config.list_objects('testminio', prefix='metadata/test/', recursive=True)
+            ),
+            self._get_obj_names(
+                self.nas_config.list_objects('testnas', prefix='metadata/test/', recursive=True)
+            )
+        )
+
+def suite():
+    suties = unittest.TestSuite()
+    suties.addTests(unittest.makeSuite(DataSaverTest))
+    return suties
+
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/tests/test_nas.py
+++ b/tests/test_nas.py
@@ -27,7 +27,7 @@ class DataSaverTest(StorageTest, unittest.TestCase):
         secret_key="miniosecretkey",
         secure=False,
     )
-    nas_config = NAS(path="/tmp")
+    nas_config = NAS(path="/tmp/unittest")
 
     def _create_bucket(self):
         self.minio_config.make_bucket('testminio')

--- a/tests/test_nas.py
+++ b/tests/test_nas.py
@@ -22,7 +22,7 @@ from matorage.nas import NAS
 
 class DataSaverTest(StorageTest, unittest.TestCase):
     minio_config = Minio(
-        endpoint="127.0.0.1:9000",
+        endpoint="127.0.0.1:9001",
         access_key="minio",
         secret_key="miniosecretkey",
         secure=False,

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -25,7 +25,7 @@ class OptimizerTest(unittest.TestCase):
     optimizer_config_file = None
     optimizer_manager = None
     storage_config = {
-        "endpoint": "127.0.0.1:9000",
+        "endpoint": "127.0.0.1:9001",
         "access_key": "minio",
         "secret_key": "miniosecretkey",
         "secure": False,

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -30,6 +30,9 @@ class OptimizerTest(unittest.TestCase):
         "secret_key": "miniosecretkey",
         "secure": False,
     }
+    nas_config = {
+        "endpoint": "/tmp",
+    }
 
     def check_nas(self, endpoint):
         _url_or_path = "//" + endpoint

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -31,7 +31,7 @@ class OptimizerTest(unittest.TestCase):
         "secure": False,
     }
     nas_config = {
-        "endpoint": "/tmp",
+        "endpoint": "/tmp/unittest",
     }
 
     def check_nas(self, endpoint):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -24,7 +24,7 @@ class StorageTest(unittest.TestCase):
     minio_config = None
     nas_config = None
     storage_config = {
-        "endpoint": "127.0.0.1:9000",
+        "endpoint": "127.0.0.1:9001",
         "access_key": "minio",
         "secret_key": "miniosecretkey",
         "secure": False,

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,56 @@
+# Copyright 2020-present Tae Hwan Jung
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+from minio import Minio
+from urllib.parse import urlsplit
+
+from matorage.nas import NAS
+
+
+class StorageTest(unittest.TestCase):
+    minio_config = None
+    nas_config = None
+    storage_config = {
+        "endpoint": "127.0.0.1:9000",
+        "access_key": "minio",
+        "secret_key": "miniosecretkey",
+        "secure": False,
+    }
+
+    def check_nas(self, endpoint):
+        _url_or_path = "//" + endpoint
+        u = urlsplit(_url_or_path)
+        if u.path:
+            return True
+        if u.netloc:
+            return False
+        raise ValueError("This endpoint is not suitable.")
+
+    def tearDown(self):
+        if self.minio_config:
+            objects = self.minio_config.list_objects('testminio', recursive=True)
+            for obj in objects:
+                self.minio_config.remove_object('testminio', obj.object_name)
+            self.minio_config.remove_bucket('testminio')
+
+        if self.nas_config:
+            objects = self.nas_config.list_objects('testnas', recursive=True)
+            for obj in objects:
+                self.nas_config.remove_object('testnas', obj.object_name)
+            self.nas_config.remove_bucket('testnas')
+
+        if os.path.exists('test'):
+            os.remove('test')

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -12,6 +12,7 @@ from matorage.utils import is_torch_available, is_tf_available
 def suite():
     test_modules = [
         "tests.test_datasaver",
+        "tests.test_nas",
     ]
     if is_torch_available():
         test_modules.extend([

--- a/tests/test_tf_data.py
+++ b/tests/test_tf_data.py
@@ -179,6 +179,39 @@ class TFDataTest(DataTest, unittest.TestCase):
 
         self.assertEqual(_pre_file_mapper, _next_file_mapper)
 
+    def test_tf_saver_nas(self):
+        self.data_config = DataConfig(
+            **self.nas_config,
+            dataset_name="test_tf_saver_nas",
+            additional={"framework": "tensorflow"},
+            attributes=[
+                DataAttribute("image", "uint8", (2, 2), itemsize=32),
+                DataAttribute("target", "uint8", (1), itemsize=32),
+            ]
+        )
+
+        self.data_saver = DataSaver(config=self.data_config)
+
+        self.data_saver(
+            {
+                "image": np.asarray([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]),
+                "target": np.asarray([0, 1]),
+            }
+        )
+        self.data_saver.disconnect()
+
+    def test_tf_loader_nas(self):
+        from matorage.tensorflow import Dataset
+
+        self.test_tf_saver_nas()
+
+        self.dataset = Dataset(config=self.data_config)
+
+        for batch_idx, (image, target) in enumerate(
+            tqdm(self.dataset.dataloader, total=2)
+        ):
+            pass
+
 def suite():
     return unittest.TestSuite(unittest.makeSuite(TFDataTest))
 

--- a/tests/test_tf_model.py
+++ b/tests/test_tf_model.py
@@ -91,7 +91,7 @@ class TFModelTest(ModelTest, unittest.TestCase):
         model.fit(train_images, train_labels, epochs=5)
 
         self.model_config = ModelConfig(
-            endpoint="127.0.0.1:9000",
+            endpoint="127.0.0.1:9001",
             access_key="minio",
             secret_key="miniosecretkey",
             model_name="test_tf_mnist",
@@ -114,7 +114,7 @@ class TFModelTest(ModelTest, unittest.TestCase):
         _, correct = model.evaluate(test_images, test_labels, verbose=2)
 
         self.model_config = ModelConfig(
-            endpoint="127.0.0.1:9000",
+            endpoint="127.0.0.1:9001",
             access_key="minio",
             secret_key="miniosecretkey",
             model_name="test_tf_mnist",

--- a/tests/test_tf_model.py
+++ b/tests/test_tf_model.py
@@ -16,7 +16,7 @@ import gc
 import unittest
 import tensorflow as tf
 from tensorflow import keras
-from tensorflow.keras import layers, Sequential
+from unittest.case import SkipTest
 
 from tests.test_model import ModelTest
 
@@ -27,6 +27,8 @@ from matorage.testing_utils import require_tf
 
 @require_tf
 class TFModelTest(ModelTest, unittest.TestCase):
+    flag = False
+
     def create_model(self):
         model = tf.keras.models.Sequential(
             [
@@ -76,8 +78,10 @@ class TFModelTest(ModelTest, unittest.TestCase):
 
         self.model_manager.save(self.model, step=0)
 
-    @unittest.skip("skip")
     def test_mnist_train_process(self):
+        if not self.flag:
+            raise SkipTest
+
         (train_images, train_labels), _ = tf.keras.datasets.mnist.load_data()
 
         train_labels = train_labels[:1000]
@@ -97,8 +101,10 @@ class TFModelTest(ModelTest, unittest.TestCase):
 
         self.model_manager.save(model, epoch=1)
 
-    @unittest.skip("skip")
     def test_mnist_eval_process(self):
+        if not self.flag:
+            raise SkipTest
+
         _, (test_images, test_labels) = tf.keras.datasets.mnist.load_data()
 
         test_labels = test_labels[:1000]
@@ -122,6 +128,7 @@ class TFModelTest(ModelTest, unittest.TestCase):
         assert correct < pretrained_correct
 
     def test_mnist_reloaded(self):
+        self.flag = True
 
         import multiprocessing
 
@@ -133,8 +140,10 @@ class TFModelTest(ModelTest, unittest.TestCase):
         process_eval.start()
         process_eval.join()
 
-    @unittest.skip("skip")
     def test_mnist_train_process_nas(self):
+        if not self.flag:
+            raise SkipTest
+
         (train_images, train_labels), _ = tf.keras.datasets.mnist.load_data()
 
         train_labels = train_labels[:1000]
@@ -152,8 +161,10 @@ class TFModelTest(ModelTest, unittest.TestCase):
 
         self.model_manager.save(model, epoch=1)
 
-    @unittest.skip("skip")
     def test_mnist_eval_process_nas(self):
+        if not self.flag:
+            raise SkipTest
+
         _, (test_images, test_labels) = tf.keras.datasets.mnist.load_data()
 
         test_labels = test_labels[:1000]
@@ -175,6 +186,7 @@ class TFModelTest(ModelTest, unittest.TestCase):
         assert correct < pretrained_correct
 
     def test_mnist_reloaded_nas(self):
+        self.flag = True
 
         import multiprocessing
 

--- a/tests/test_torch_data.py
+++ b/tests/test_torch_data.py
@@ -177,6 +177,38 @@ class TorchDataTest(DataTest, unittest.TestCase):
 
         self.assertEqual(_pre_file_mapper, _next_file_mapper)
 
+    def test_torch_saver_nas(self):
+        self.data_config = DataConfig(
+            **self.nas_config,
+            dataset_name="test_torch_saver_nas",
+            additional={"framework": "pytorch"},
+            attributes=[
+                DataAttribute("image", "uint8", (2, 2), itemsize=32),
+                DataAttribute("target", "uint8", (1), itemsize=32),
+            ]
+        )
+
+        self.data_saver = DataSaver(config=self.data_config)
+
+        self.data_saver(
+            {
+                "image": np.asarray([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]),
+                "target": np.asarray([0, 1]),
+            }
+        )
+        self.data_saver.disconnect()
+
+    def test_torch_loader_nas(self):
+        from matorage.torch import Dataset
+
+        self.test_torch_saver_nas()
+
+        self.dataset = Dataset(config=self.data_config)
+        loader = DataLoader(self.dataset, batch_size=64, num_workers=8, shuffle=True)
+
+        for batch_idx, (image, target) in enumerate(tqdm(loader)):
+            pass
+
 def suite():
     return unittest.TestSuite(unittest.makeSuite(TorchDataTest))
 

--- a/tests/test_torch_model.py
+++ b/tests/test_torch_model.py
@@ -20,6 +20,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
 from torchvision import datasets, transforms
+from unittest.case import SkipTest
 
 from tests.test_model import ModelTest
 
@@ -50,6 +51,7 @@ class TorchModelTest(ModelTest, unittest.TestCase):
     transform = transforms.Compose(
         [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
     )
+    flag = False
 
     def test_torchmodel_saver(self, model_config=None, save_to_json_file=False):
         if model_config is None:
@@ -115,8 +117,10 @@ class TorchModelTest(ModelTest, unittest.TestCase):
 
         self.model_manager.load("f.weight", step=0)
 
-    @unittest.skip("skip")
-    def test_mnist_eval(self, model, device):
+    def test_mnist_eval(self, model=None, device=None):
+        if not self.flag:
+            raise SkipTest
+
         test_dataset = datasets.MNIST(
             "/tmp/data", train=False, transform=self.transform
         )
@@ -137,6 +141,8 @@ class TorchModelTest(ModelTest, unittest.TestCase):
         return correct
 
     def test_mnist_reloaded(self):
+        self.flag = True
+
         import torch.optim as optim
 
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -177,6 +183,8 @@ class TorchModelTest(ModelTest, unittest.TestCase):
         assert correct < pretrained_correct
 
     def test_mnist_reloaded_nas(self):
+        self.flag = True
+
         import torch.optim as optim
 
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")


### PR DESCRIPTION
#21 

I compared both the `list_object` function of minio and the `list_object` function that I directly override(NAS class). At this time, only when the prefix is'metadata/test/', there is a problem that the two do not match. Be careful about this.

### Add unittests for NAS
- data saver and data loader
- model saver and model loader
- optimizer saver and optimizer loader

As one problem, we found a problem that `unittest.skip` cannot be called in the same class. Therefore, this [stackoverflow answer](https://stackoverflow.com/a/44581950) solved this.