### PR TITLE
Fixed unittest errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ services:
 
 before_install:
   - mkdir /tmp/unittest
+  - sudo chown -R $USER /tmp/unittest
   - docker pull minio/minio
   - docker run -it -d -p 9001:9000 --restart always -e "MINIO_ACCESS_KEY=minio" -e "MINIO_SECRET_KEY=miniosecretkey" -v /tmp/unittest:/container/vol minio/minio gateway nas /container/vol
 

--- a/change_logs/v0.3.0.md
+++ b/change_logs/v0.3.0.md
@@ -13,6 +13,12 @@ version : v0.3.0
     - Add optimizer saver and optimizer loader for NAS.
 - Fixed deadlock(`join` in multiprocessing) when model is reloaded in tensorflow. This bug created a timeout error in travis ci.
 - Fixed an error when an empty string entered in the `group` in tensorflow optimizer.
+- Split downloaded data cache folder with `~/.matorage`(default `cache_folder_path`).
+- Fixed unittest nas folder permission in `.travis`.
+- Fixed `group` type from `int` to `str`, so tensorflow and torch are working fine.
+- Fixed `cache_folder_path` not in `DataS3Test`.
+- Fixed unittest main function to be right.
+- Split `test_datasaver_filetype` to torch and tensorflow.
 
 ### New Features
 - Add context manager for `DataSaver` #24.

--- a/matorage/optimizer/manager.py
+++ b/matorage/optimizer/manager.py
@@ -87,6 +87,7 @@ class Manager(object):
         self._uploader_closing()
 
     def _save_param(self, step, group, name, weight):
+        group = str(group)
         _local_file = tempfile.mktemp(f"{name}.h5")
 
         _file = tables.open_file(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -81,6 +81,7 @@ class DataTest(unittest.TestCase):
     'access_key' not in os.environ or 'secret_key' not in os.environ, 'S3 Skip'
 )
 class DataS3Test(unittest.TestCase):
+    cache_folder_path = "/tmp/unittest_cache"
 
     data_config = None
     data_config_file = None

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -46,9 +46,9 @@ class DataTest(unittest.TestCase):
             return False
         raise ValueError("This endpoint is not suitable.")
 
-    def setUp(self):
-        if os.path.exists(self.cache_folder_path):
-            shutil.rmtree(self.cache_folder_path)
+    # def setUp(self):
+    #     if os.path.exists(self.cache_folder_path):
+    #         shutil.rmtree(self.cache_folder_path)
 
     def tearDown(self):
         if self.data_saver is not None:

--- a/tests/test_datasaver.py
+++ b/tests/test_datasaver.py
@@ -416,7 +416,7 @@ class DataSaverTest(DataTest, unittest.TestCase):
 
         self.data_saver.disconnect()
 
-        self.dataset = Dataset(config=self.data_config)
+        self.dataset = Dataset(config=self.data_config, cache_folder_path=self.cache_folder_path)
         self.assertEqual(
             self.dataset.get_filetype_list, ["file"]
         )
@@ -489,7 +489,7 @@ class DataS3SaverTest(DataS3Test, unittest.TestCase):
 
         self.data_saver.disconnect()
 
-        self.dataset = Dataset(config=self.data_config)
+        self.dataset = Dataset(config=self.data_config, cache_folder_path=self.cache_folder_path)
         self.assertEqual(
             self.dataset.get_filetype_list, ["file"]
         )

--- a/tests/test_datasaver.py
+++ b/tests/test_datasaver.py
@@ -395,35 +395,6 @@ class DataSaverTest(DataTest, unittest.TestCase):
             self.data_saver({"x": x})
             self.data_saver.disconnect()
 
-
-    def test_datasaver_filetype(self):
-        from matorage.torch import Dataset
-
-        self.data_config = DataConfig(
-            **self.storage_config,
-            dataset_name="test_datasaver_filetype",
-            attributes=[DataAttribute("x", "float64", (2), itemsize=32)],
-        )
-        self.data_saver = DataSaver(config=self.data_config)
-        x = np.asarray([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
-        self.assertEqual(x.shape, (3, 2))
-        self.data_saver({"x": x})
-
-        _file = open("test.txt", "w")
-        _file.write('this is test')
-        self.data_saver({"file": "test.txt"}, filetype=True)
-        _file.close()
-
-        self.data_saver.disconnect()
-
-        self.dataset = Dataset(config=self.data_config, cache_folder_path=self.cache_folder_path)
-        self.assertEqual(
-            self.dataset.get_filetype_list, ["file"]
-        )
-        _local_filepath = self.dataset.get_filetype_from_key("file")
-        with open(_local_filepath, 'r') as f:
-            self.assertEqual(f.read(), 'this is test')
-
     def test_datasaver_context_manager(self):
         self.data_config = DataConfig(
             **self.storage_config,

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -46,4 +46,4 @@ def test(verbose=False):
         return 1
 
 if __name__ == '__main__':
-    test()
+    unittest.main(defaultTest='test')

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -37,13 +37,5 @@ def suite():
         alltests.addTest(test_suite())
     return alltests
 
-
-def test(verbose=False):
-    result = unittest.TextTestRunner(verbosity=1 + int(verbose)).run(suite())
-    if result.wasSuccessful():
-        return 0
-    else:
-        return 1
-
 if __name__ == '__main__':
-    unittest.main(defaultTest='test')
+    unittest.main(defaultTest="suite", warnings=False)

--- a/tests/test_tf_data.py
+++ b/tests/test_tf_data.py
@@ -179,6 +179,34 @@ class TFDataTest(DataTest, unittest.TestCase):
 
         self.assertEqual(_pre_file_mapper, _next_file_mapper)
 
+    def test_datasaver_filetype(self):
+        from matorage.tensorflow import Dataset
+
+        self.data_config = DataConfig(
+            **self.storage_config,
+            dataset_name="test_datasaver_filetype",
+            attributes=[DataAttribute("x", "float64", (2), itemsize=32)],
+        )
+        self.data_saver = DataSaver(config=self.data_config)
+        x = np.asarray([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        self.assertEqual(x.shape, (3, 2))
+        self.data_saver({"x": x})
+
+        _file = open("test.txt", "w")
+        _file.write('this is test')
+        self.data_saver({"file": "test.txt"}, filetype=True)
+        _file.close()
+
+        self.data_saver.disconnect()
+
+        self.dataset = Dataset(config=self.data_config, cache_folder_path=self.cache_folder_path)
+        self.assertEqual(
+            self.dataset.get_filetype_list, ["file"]
+        )
+        _local_filepath = self.dataset.get_filetype_from_key("file")
+        with open(_local_filepath, 'r') as f:
+            self.assertEqual(f.read(), 'this is test')
+
     def test_tf_saver_nas(self):
         self.data_config = DataConfig(
             **self.nas_config,

--- a/tests/test_tf_data.py
+++ b/tests/test_tf_data.py
@@ -62,7 +62,7 @@ class TFDataTest(DataTest, unittest.TestCase):
 
         self.test_tf_saver()
 
-        self.dataset = Dataset(config=self.data_config)
+        self.dataset = Dataset(config=self.data_config, cache_folder_path=self.cache_folder_path)
 
         for batch_idx, (image, target) in enumerate(
             tqdm(self.dataset.dataloader, total=2)
@@ -85,7 +85,7 @@ class TFDataTest(DataTest, unittest.TestCase):
 
         self.test_tf_saver(data_config=data_config)
 
-        self.dataset = Dataset(config=data_config)
+        self.dataset = Dataset(config=data_config, cache_folder_path=self.cache_folder_path)
 
         for batch_idx, (image, target) in enumerate(
             tqdm(self.dataset.dataloader, total=2)
@@ -97,7 +97,7 @@ class TFDataTest(DataTest, unittest.TestCase):
 
         self.test_tf_loader()
 
-        dataset = Dataset(config=self.data_config, index=True)
+        dataset = Dataset(config=self.data_config, index=True, cache_folder_path=self.cache_folder_path)
 
         assert tf.reduce_all(
             tf.equal(dataset[0][0], tf.constant([[1, 2], [3, 4]], dtype=tf.uint8))
@@ -120,7 +120,7 @@ class TFDataTest(DataTest, unittest.TestCase):
 
         self.test_tf_saver(data_config=data_config)
 
-        dataset = Dataset(config=self.data_config, index=True)
+        dataset = Dataset(config=self.data_config, index=True, cache_folder_path=self.cache_folder_path)
 
         assert tf.reduce_all(
             tf.equal(dataset[0][0], tf.constant([[1, 2], [3, 4]], dtype=tf.uint8))
@@ -155,7 +155,7 @@ class TFDataTest(DataTest, unittest.TestCase):
 
         self.data_config = DataConfig.from_json_file(self.data_config_file)
 
-        self.dataset = Dataset(config=self.data_config)
+        self.dataset = Dataset(config=self.data_config, cache_folder_path=self.cache_folder_path)
 
         for batch_idx, (image, target) in enumerate(
             tqdm(self.dataset.dataloader, total=2)
@@ -171,7 +171,7 @@ class TFDataTest(DataTest, unittest.TestCase):
             with open(self.dataset.cache_path) as f:
                 _pre_file_mapper = json.load(f)
 
-        self.dataset = Dataset(config=self.data_config, clear=False)
+        self.dataset = Dataset(config=self.data_config, clear=False, cache_folder_path=self.cache_folder_path)
 
         if os.path.exists(self.dataset.cache_path):
             with open(self.dataset.cache_path) as f:
@@ -205,7 +205,7 @@ class TFDataTest(DataTest, unittest.TestCase):
 
         self.test_tf_saver_nas()
 
-        self.dataset = Dataset(config=self.data_config)
+        self.dataset = Dataset(config=self.data_config, cache_folder_path=self.cache_folder_path)
 
         for batch_idx, (image, target) in enumerate(
             tqdm(self.dataset.dataloader, total=2)

--- a/tests/test_torch_data.py
+++ b/tests/test_torch_data.py
@@ -63,7 +63,7 @@ class TorchDataTest(DataTest, unittest.TestCase):
 
         self.test_torch_saver()
 
-        self.dataset = Dataset(config=self.data_config)
+        self.dataset = Dataset(config=self.data_config, cache_folder_path=self.cache_folder_path)
         loader = DataLoader(self.dataset, batch_size=64, num_workers=8, shuffle=True)
 
         for batch_idx, (image, target) in enumerate(tqdm(loader)):
@@ -85,7 +85,7 @@ class TorchDataTest(DataTest, unittest.TestCase):
 
         self.test_torch_saver(data_config=data_config)
 
-        self.dataset = Dataset(config=data_config)
+        self.dataset = Dataset(config=data_config, cache_folder_path=self.cache_folder_path)
         loader = DataLoader(self.dataset, batch_size=64, num_workers=8, shuffle=True)
 
         for batch_idx, (image, target) in enumerate(tqdm(loader)):
@@ -96,7 +96,7 @@ class TorchDataTest(DataTest, unittest.TestCase):
 
         self.test_torch_saver()
 
-        dataset = Dataset(config=self.data_config, index=True)
+        dataset = Dataset(config=self.data_config, index=True, cache_folder_path=self.cache_folder_path)
 
         assert torch.equal(
             dataset[0][0], torch.tensor([[1, 2], [3, 4]], dtype=torch.uint8)
@@ -119,7 +119,7 @@ class TorchDataTest(DataTest, unittest.TestCase):
 
         self.test_torch_saver(data_config=data_config)
 
-        dataset = Dataset(config=self.data_config, index=True)
+        dataset = Dataset(config=self.data_config, index=True, cache_folder_path=self.cache_folder_path)
 
         assert torch.equal(
             dataset[0][0], torch.tensor([[1, 2], [3, 4]], dtype=torch.uint8)
@@ -154,7 +154,7 @@ class TorchDataTest(DataTest, unittest.TestCase):
 
         self.data_config = DataConfig.from_json_file(self.data_config_file)
 
-        self.dataset = Dataset(config=self.data_config)
+        self.dataset = Dataset(config=self.data_config, cache_folder_path=self.cache_folder_path)
         loader = DataLoader(self.dataset, batch_size=64, num_workers=8, shuffle=True)
 
         for batch_idx, (image, target) in enumerate(tqdm(loader)):
@@ -169,7 +169,7 @@ class TorchDataTest(DataTest, unittest.TestCase):
             with open(self.dataset.cache_path) as f:
                 _pre_file_mapper = json.load(f)
 
-        self.dataset = Dataset(config=self.data_config, clear=False)
+        self.dataset = Dataset(config=self.data_config, clear=False, cache_folder_path=self.cache_folder_path)
 
         if os.path.exists(self.dataset.cache_path):
             with open(self.dataset.cache_path) as f:
@@ -203,7 +203,7 @@ class TorchDataTest(DataTest, unittest.TestCase):
 
         self.test_torch_saver_nas()
 
-        self.dataset = Dataset(config=self.data_config)
+        self.dataset = Dataset(config=self.data_config, cache_folder_path=self.cache_folder_path)
         loader = DataLoader(self.dataset, batch_size=64, num_workers=8, shuffle=True)
 
         for batch_idx, (image, target) in enumerate(tqdm(loader)):

--- a/tests/test_torch_data.py
+++ b/tests/test_torch_data.py
@@ -177,6 +177,34 @@ class TorchDataTest(DataTest, unittest.TestCase):
 
         self.assertEqual(_pre_file_mapper, _next_file_mapper)
 
+    def test_datasaver_filetype(self):
+        from matorage.torch import Dataset
+
+        self.data_config = DataConfig(
+            **self.storage_config,
+            dataset_name="test_datasaver_filetype",
+            attributes=[DataAttribute("x", "float64", (2), itemsize=32)],
+        )
+        self.data_saver = DataSaver(config=self.data_config)
+        x = np.asarray([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        self.assertEqual(x.shape, (3, 2))
+        self.data_saver({"x": x})
+
+        _file = open("test.txt", "w")
+        _file.write('this is test')
+        self.data_saver({"file": "test.txt"}, filetype=True)
+        _file.close()
+
+        self.data_saver.disconnect()
+
+        self.dataset = Dataset(config=self.data_config, cache_folder_path=self.cache_folder_path)
+        self.assertEqual(
+            self.dataset.get_filetype_list, ["file"]
+        )
+        _local_filepath = self.dataset.get_filetype_from_key("file")
+        with open(_local_filepath, 'r') as f:
+            self.assertEqual(f.read(), 'this is test')
+
     def test_torch_saver_nas(self):
         self.data_config = DataConfig(
             **self.nas_config,


### PR DESCRIPTION
- https://github.com/graykode/matorage/pull/31/commits/3b6ddf7bb1983cb365bc904f945bf5ee90b76dc9 : Split downloaded data cache folder with `~/.matorage`(default `cache_folder_path`).
- https://github.com/graykode/matorage/pull/31/commits/57c9a7d0de69997caca6b95617c968c47050919a : Fixed unittest nas folder permission in `.travis`.
- https://github.com/graykode/matorage/pull/31/commits/1b39a28e17773f8b35d9810015f6979b0796f272 : Fixed `group` type from `int` to `str`, so tensorflow and torch are working fine.
- https://github.com/graykode/matorage/pull/31/commits/774ebec30ca87d5296afe78e9e21ac5516e893f6 : Fixed `cache_folder_path` not in `DataS3Test`.
- https://github.com/graykode/matorage/pull/31/commits/9bad92aef60db1b8a9ca79ce83c986add91f8568, https://github.com/graykode/matorage/pull/31/commits/3f9ba83cf809a1d7d0698214fb7e9c27c9dad4e9 : Fixed unittest main function to be right.
- https://github.com/graykode/matorage/pull/31/commits/6ad21efc6ddc59ee9217683085c801db9e990be6 : Split `test_datasaver_filetype` to torch and tensorflow.